### PR TITLE
feat: add support for codediff

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ only necessary if you want to change the default behavior.
 
 ```lua
 require("jujutsu-nvim").setup({
-  -- Diff viewer: "difftastic", "diffview", "none"
+  -- Diff viewer: "difftastic", "diffview", "codediff", none"
   diff_preset = "difftastic",  -- default
 
   -- Help window position: "center", "bottom_right"
@@ -242,6 +242,7 @@ require("jujutsu-nvim").setup({
 
 - **`"difftastic"`** (default) - Opens diffs using [difftastic.nvim](https://github.com/clabby/difftastic.nvim) in a new tab
 - **`"diffview"`** - Opens diffs using [diffview.nvim](https://github.com/sindrets/diffview.nvim)
+- **`"codediff"`** - Opens diffs using [codediff.nvim](https://github.com/esmuellert/codediff.nvim)
 - **`"none"`** - Disables the default `<CR>` behavior (useful if you want to add your own via keymaps)
 
 ### Custom Keymaps

--- a/lua/jujutsu-nvim/init.lua
+++ b/lua/jujutsu-nvim/init.lua
@@ -35,12 +35,12 @@ vim.api.nvim_set_hl(0, "JJLogChange", { link = "CursorLine" })
 --- @field desc string Description of the keybinding
 
 --- @class JJConfig
---- @field diff_preset "difftastic"|"diffview"|"none" Diff viewer preset
+--- @field diff_preset "difftastic"|"diffview"|"codediff"|"none" Diff viewer preset
 --- @field help_position "center"|"bottom_right" Help window position
 --- @field keymap table<string, KeymapBinding> Keymap configuration
 
 local default_config = {
-  -- Diff viewer preset options: "difftastic", "diffview" or "none"
+  -- Diff viewer preset options: "difftastic", "diffview", "codediff" or "none"
   diff_preset = "difftastic",
   -- Help window position: "center" or "bottom_right"
   help_position = "center",
@@ -87,6 +87,15 @@ local diff_presets = {
       vim.cmd(string.format("DiffviewOpen %s^!", changes[1].commit_sha))
     else
       vim.cmd(string.format("DiffviewOpen %s...%s", changes[1].commit_sha, changes[#changes].commit_sha))
+    end
+  end,
+
+  codediff = function(changes)
+    if #changes == 1 then
+      -- Diff with parent change
+        vim.cmd(string.format("CodeDiff %s %s", changes[1].commit_sha, changes[1].commit_sha .. "~1"))
+    else
+      vim.cmd(string.format("CodeDiff %s %s", changes[1].commit_sha, changes[#changes].commit_sha))
     end
   end,
 


### PR DESCRIPTION
This differs slightly from diffview, since you need to provide two revisions to view what has happened in one change. Solved here by providing "rev" and "rev-1" to jj.
Not sure how one wants to support if only one rev to the viewer, but put some support there anyway.