### PR TITLE
(fix): diff multiple changes with diffview

### DIFF
--- a/lua/jujutsu-nvim/init.lua
+++ b/lua/jujutsu-nvim/init.lua
@@ -96,7 +96,7 @@ local diff_presets = {
     if #changes == 1 then
       vim.cmd(string.format("DiffviewOpen %s^!", changes[1].commit_sha))
     else
-      vim.cmd(string.format("DiffviewOpen %s...%s", changes[1].commit_sha, changes[#changes].commit_sha))
+      vim.cmd(string.format("DiffviewOpen %s~1..%s", changes[#changes].commit_sha, changes[1].commit_sha))
     end
   end,
 


### PR DESCRIPTION
`Diffview` wasn't working for multiple selection. 

The right syntax for diffing ranges in `Diffview` is the same as for `git`, that's `..`, `...` is used for diffing branches (by finding the common ancestor). Also, the order was wrong, and the first commit is excluded from the range. That's why we reach for the parent. I guess that's exactly the same story in `CodeDiff`