### PR TITLE
(fix): don't uppercase keys in the menus

### DIFF
--- a/lua/jujutsu-nvim/dialog_window.lua
+++ b/lua/jujutsu-nvim/dialog_window.lua
@@ -34,7 +34,7 @@ M.show_floating_options = function(opts)
   table.insert(lines, "")
   local highlights = {}  -- Track where to highlight keys
   for _, option in ipairs(options) do
-    local line = string.format("    %s  %s", option.key:upper(), option.label)
+    local line = string.format("    %s  %s", option.key, option.label)
     table.insert(lines, line)
     -- Track position of key for highlighting (accounting for padding)
     local line_idx = #lines - 1  -- 0-based index


### PR DESCRIPTION
All keys are uppercased in the menu. That's misleading, as the actual keys are lowercase. Hence, the uppercase keys don't work. 

This is not the case for the main menu tho which works fine. But at least, the `bookmark` and `New change` have this issue.